### PR TITLE
implemented css export helper, omitted tailwind v4 class variables for v1.1/2

### DIFF
--- a/code.ts
+++ b/code.ts
@@ -214,6 +214,38 @@ figma.ui.onmessage = async (
 
   }
 
+  function buildCssExports(
+  colors: Array<{ hexCode: string; hexName?: string | null }>
+) {
+  let idx = 0;
+
+  const safeName = (name?: string | null) => {
+    const raw = (name && name.trim()) ? name.trim() : `untitled${idx++}`;
+    // make it CSS-variable friendly
+    return raw
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-_]/g, "");
+  };
+
+  const cssVars: string[] = [];
+  const scssVars: string[] = [];
+  const tailwindRgbRefs: string[] = [];
+
+  for (const c of colors) {
+    const n = safeName(c.hexName);
+
+    cssVars.push(`--${n}-color: ${c.hexCode};`);
+    scssVars.push(`$${n}-color: ${c.hexCode};`);
+
+    // For Tailwind style usage when you define --color-* as "R G B"
+    tailwindRgbRefs.push(`'rgb(var(--color-${n}) / <alpha-value>)'`);
+  }
+
+  return { cssVars, scssVars, tailwindRgbRefs };
+}
+console.log(buildCssExports(msg.colorPaletteObjects))
+
 };
 
 


### PR DESCRIPTION
Generator now has the ability to export while generating the desired CSS export.
Tailwind v4 variables omitted till v1.1/2 due to platform issues